### PR TITLE
Bump upper-constraints to resolve critical vulnerabilities 2023.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -431,7 +431,7 @@ xmltodict===0.13.0
 pyasn1===0.4.8
 directord===0.12.0
 oslo.rootwrap===7.0.1
-Django===3.2.16
+Django===3.2.19
 pexpect===4.8.0
 contextvars===2.4
 cmd2===2.4.2


### PR DESCRIPTION
Bump Django to 3.2.19 to resolve critical vulnerability CVE-2023-31047 at 2023.1 Horizon

Remaining critical vulnerabilities are out-of-scope of Openstack

Grafana
- CVE-2023-49569

Prometheus
- CVE-2021-4238
- CVE-2022-40083