### PR TITLE
Bump upper-constraints to resolve critical vulnerabilities zed

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -431,7 +431,7 @@ xmltodict===0.13.0
 pyasn1===0.4.8
 directord===0.12.0
 oslo.rootwrap===6.3.1
-Django===3.2.15
+Django===3.2.19
 pexpect===4.8.0
 contextvars===2.4
 cmd2===2.4.2


### PR DESCRIPTION
Bump Django to 3.2.19 to resolve critical vulnerability CVE-2023-31047 at Zed Horizon

Fix for ciritical vulnerabilities that is not part of openstack will be addressed with SKC change

Grafana
- CVE-2023-49569

Prometheus
- CVE-2021-4238
- CVE-2022-40083