### PR TITLE
Bump upper-constraints to resolve critical vulnerabilities yoga

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -463,7 +463,7 @@ pyasn1===0.4.8
 directord===0.12.0
 oslo.rootwrap===6.3.1
 pyroute2.nslink===0.6.6
-Django===3.2.12
+Django===3.2.19
 pexpect===4.8.0
 contextvars===2.4
 cmd2===2.4.0


### PR DESCRIPTION
Bump Django to 3.2.19 to resolve critical vulnerability CVE-2023-31047 at Yoga Horizon

Remaining critical vulnerabilities that are out-of-scope of Openstack will be addressed with https://github.com/stackhpc/stackhpc-kayobe-config/pull/1071

Grafana
- CVE-2023-49569

Prometheus
- CVE-2021-4238
- CVE-2022-40083