### PR TITLE
Kolla vulnerability fix 2023.1 critical & high

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -183,7 +183,7 @@ PyYAML===6.0
 beautifulsoup4===4.11.1
 os-net-config===16.0.0
 ovs===2.17.7
-cryptography===42.0.4
+cryptography===38.0.2
 httpcore===0.15.0
 URLObject===2.4.3
 nocasedict===1.0.4

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -198,7 +198,7 @@ requests-mock===1.10.0
 os-apply-config===13.1.0
 prometheus-client===0.14.1
 oslosphinx===4.18.0
-gunicorn===20.1.0
+gunicorn===22.0.0
 storpool===7.1.0
 textfsm===1.1.2
 python-3parclient===4.2.12

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -127,7 +127,7 @@ doc8===0.11.2
 pymongo===4.2.0
 python-cloudkittyclient===4.7.0
 soupsieve===2.3.2.post1
-sqlparse===0.4.3
+sqlparse===0.5.0
 oslotest===4.5.0
 jsonpointer===2.3
 defusedxml===0.7.1

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -183,7 +183,7 @@ PyYAML===6.0
 beautifulsoup4===4.11.1
 os-net-config===16.0.0
 ovs===2.17.7
-cryptography===38.0.2
+cryptography===42.0.4
 httpcore===0.15.0
 URLObject===2.4.3
 nocasedict===1.0.4
@@ -431,7 +431,7 @@ xmltodict===0.13.0
 pyasn1===0.4.8
 directord===0.12.0
 oslo.rootwrap===7.0.1
-Django===3.2.19
+Django===3.2.23
 pexpect===4.8.0
 contextvars===2.4
 cmd2===2.4.2
@@ -457,7 +457,7 @@ dfs-sdk===1.2.27
 sentinels===1.0.0
 kombu===5.2.4
 distro===1.7.0
-zstd===1.5.2.6
+zstd===1.5.4.0
 yaql===3.0.0
 requestsexceptions===1.4.0
 testresources===2.0.1
@@ -502,7 +502,7 @@ os-vif===3.1.1
 hyperlink===21.0.0
 mitba===1.1.1
 python-masakariclient===8.1.0
-Werkzeug===2.2.2
+Werkzeug===2.2.3
 pyasn1-modules===0.2.8
 APScheduler===3.9.1
 monotonic===1.6
@@ -558,7 +558,7 @@ confluent-kafka===1.9.2
 xvfbwrapper===0.2.9
 tosca-parser===2.8.0
 charset-normalizer===2.1.1
-Flask===2.2.2
+Flask===2.2.5
 httpx===0.23.0
 sqlalchemy-filters===0.12.0
 marathon===0.13.0

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -101,7 +101,7 @@ simplejson===3.17.6
 types-paramiko===2.11.6
 immutables===0.19
 python-swiftclient===4.2.0
-pyOpenSSL===22.1.0
+pyOpenSSL===24.0.0
 monasca-common===3.7.0
 zeroconf===0.39.1
 scipy===1.9.1
@@ -183,7 +183,7 @@ PyYAML===6.0
 beautifulsoup4===4.11.1
 os-net-config===16.0.0
 ovs===2.17.7
-cryptography===38.0.2
+cryptography===42.0.4
 httpcore===0.15.0
 URLObject===2.4.3
 nocasedict===1.0.4

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -431,7 +431,7 @@ xmltodict===0.13.0
 pyasn1===0.4.8
 directord===0.12.0
 oslo.rootwrap===7.0.1
-Django===3.2.16
+Django===3.2.19
 pexpect===4.8.0
 contextvars===2.4
 cmd2===2.4.2


### PR DESCRIPTION
Bump Django to fix CVE-2023-31047, CVE-2023-23969, CVE-2023-24580, CVE-2023-36053, CVE-2023-46695 (Affecting Horizon)
Bump Flask to fix CVE-2023-30861 (Affecting Octavia, Keystone, Bifrost, Cloudkitty, Designate, Blazar)
Bump Werkzeug to fix CVE-2023-25577 (Affecting Octavia, Keystone, Designate, Magnum,Bifrost, Ironic, Cloudkitty, Blazar)
Bump zstd to fix CVE-2022-4899 (Affecting Cinder)
Bump gunicorn to fix CVE-2024-1135 (Affecting Octavia)
Bump sqlparse to fix GHSA-2m57-hf25-phgg (Affecting Bifrost)
Bump cryptography and its dependency pyOpenSSL to fix CVE-2023-0286, CVE-2023-50782, CVE-2024-26130 (Affecting almost all openstack services)