### PR TITLE
Bump PyMySQL to 1.1.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -405,7 +405,7 @@ python-rsdclient===1.0.2
 flux===1.3.5
 python-solumclient===3.7.0
 krb5===0.4.0
-PyMySQL===1.0.2
+PyMySQL===1.1.1
 uhashring===2.1
 kubernetes===24.2.0
 httplib2===0.20.4


### PR DESCRIPTION
Bump PyMySQL to 1.1.1 to address [CVE-2024-36039](https://github.com/advisories/GHSA-v9hf-5j83-6xpp)