### PR TITLE
Revert to PyMySQL 1.0.2 for Python 3.6

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -434,7 +434,8 @@ python-rsdclient===1.0.2
 flux===1.3.5
 python-solumclient===3.5.1
 krb5===0.3.0
-PyMySQL===1.1.1
+PyMySQL===1.0.2;python_version<='3.6'
+PyMySQL===1.1.1;python_version>'3.6'
 uhashring===2.1
 kubernetes===22.6.0
 httplib2===0.20.4


### PR DESCRIPTION
PyMySQL was bumped to 1.1.1 in ce4f310e8940c6c89ed7fdb40bb24f23b036d6ee
to fix a CVE, but the CentOS 8 Stream Kolla openstack-base image no
longer builds since then.

This change reverts to PyMySQL 1.0.2 for Python 3.6.
