### PR TITLE
Use stackhpc/4.7.0.3 version of glance-store

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -566,7 +566,7 @@ sphinxcontrib-devhelp===1.0.6;python_version>='3.9'
 python-blazarclient===4.0.1
 alembic===1.9.4
 execnet===2.0.2
-glance-store===4.7.0
+glance-store @ git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.3#egg=glance-store
 sphinxcontrib-programoutput===0.17
 storpool.spopenstack===3.2.0
 sphinx-testing===1.0.1


### PR DESCRIPTION
To backport performance fix of the bug https://bugs.launchpad.net/glance/+bug/2086675 ,
we need to make glance to use glance-store from StackHPC downstream fork.

This allows CIs and kolla image build to automatically pick up downstream glance-store.