### PR TITLE
Bump h11 to fix CVE-2025-43859

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -214,7 +214,7 @@ exceptiongroup===1.2.2;python_version=='3.9'
 os-client-config===2.1.0
 XStatic-Angular-Gettext===2.4.1.0
 Deprecated===1.2.18
-h11===0.14.0
+h11===0.16.0
 Pygments===2.19.1
 XStatic-Hogan===2.0.0.3
 XStatic-objectpath===1.2.1.0


### PR DESCRIPTION
Skyline-apiserver is affected to CVE-2025-43859 because of usage of old h11.
h11 0.16.0 fixes this vulnerability.