### PR TITLE
Updating packages for rl9.6 build

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -220,7 +220,7 @@ exceptiongroup===1.2.0;python_version=='3.9'
 os-client-config===2.1.0
 XStatic-Angular-Gettext===2.4.1.0
 Deprecated===1.2.14
-h11===0.16.0
+h11===0.14.0
 Pygments===2.17.2
 XStatic-Hogan===2.0.0.3
 XStatic-objectpath===1.2.1.0

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -201,7 +201,7 @@ pycryptodomex===3.20.0
 requests-mock===1.11.0
 os-apply-config===13.2.0
 oslosphinx===4.18.0
-gunicorn===21.2.0
+gunicorn===23.0.0
 storpool===7.3.0
 textfsm===1.1.2
 python-3parclient===4.2.13
@@ -220,7 +220,7 @@ exceptiongroup===1.2.0;python_version=='3.9'
 os-client-config===2.1.0
 XStatic-Angular-Gettext===2.4.1.0
 Deprecated===1.2.14
-h11===0.14.0
+h11===0.16.0
 Pygments===2.17.2
 XStatic-Hogan===2.0.0.3
 XStatic-objectpath===1.2.1.0
@@ -527,7 +527,7 @@ os-vif===3.5.0
 hyperlink===21.0.0
 mitba===1.1.1
 python-masakariclient===8.4.0
-Werkzeug===3.0.1
+Werkzeug===3.0.3
 pyasn1-modules===0.3.0
 APScheduler===3.10.4
 xmlschema===2.5.1


### PR DESCRIPTION
gunicorn update to 23.0.0 fixes CVE:
- https://avd.aquasec.com/nvd/cve-2024-1135 (this is fixed already in 22.0.0)
- https://avd.aquasec.com/nvd/cve-2024-6827

Werkzeug upade fixes CVE: 
- https://avd.aquasec.com/nvd/cve-2024-34069