### PR TITLE
bump Django to 4.2.27

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -437,7 +437,7 @@ botocore===1.36.26
 xmltodict===0.14.2
 pyasn1===0.6.0
 oslo.rootwrap===7.5.1
-Django===4.2.19
+Django===4.2.27
 pexpect===4.9.0
 contextvars===2.4
 cmd2===2.5.11


### PR DESCRIPTION
To prevent CVE-2025-64459, CVE-2025-13372 and related issues
See https://docs.djangoproject.com/en/5.1/releases/4.2.27/ for release notes