### PR TITLE
Bump Django to 4.2.28 in 2024.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -454,7 +454,7 @@ botocore===1.34.44
 xmltodict===0.13.0
 pyasn1===0.5.1
 oslo.rootwrap===7.2.0
-Django===4.2.15
+Django===4.2.28
 pexpect===4.9.0
 contextvars===2.4
 cmd2===2.4.3


### PR DESCRIPTION
to prevent CVE-2025-64459, CVE-2025-13372 and related

See #147 for 2025.1