### PR TITLE
Bump glance-store requirement to 4.7.1.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -566,7 +566,7 @@ sphinxcontrib-devhelp===1.0.6;python_version>='3.9'
 python-blazarclient===4.0.1
 alembic===1.9.4
 execnet===2.0.2
-glance-store @ git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.6#egg=glance-store
+glance-store @ git+https://github.com/stackhpc/glance_store@stackhpc/4.7.1.1#egg=glance-store
 sphinxcontrib-programoutput===0.17
 storpool.spopenstack===3.2.0
 sphinx-testing===1.0.1


### PR DESCRIPTION
No functional change: the version number should already have been higher than 4.7.1 but it was not bumped because of missing tags in our fork.