### PR TITLE
Bump PyYAML from 6.0 to 6.0.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -179,7 +179,7 @@ python-subunit===1.4.2
 tornado===6.2
 pycparser===2.21
 mock===4.0.3
-PyYAML===6.0
+PyYAML===6.0.1
 beautifulsoup4===4.11.1
 os-net-config===16.0.0
 ovs===2.17.7


### PR DESCRIPTION
Our container image build workflow uses Python 3.12 and it does not support PyYAML 6.0.
Bumping to 6.0.1 as this version is supported by Python 3.12 and does not exceed the version used by OpenStack 2024.1