### PR TITLE
Use keystoneauth1 5.7.0 if python version>=3.12

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -540,7 +540,8 @@ cachetools===5.3.2
 ws4py===0.5.1
 sphinxcontrib-qthelp===1.0.3;python_version=='3.8'
 sphinxcontrib-qthelp===1.0.7;python_version>='3.9'
-keystoneauth1===5.6.1
+keystoneauth1===5.6.1;python_version<'3.12'
+keystoneauth1===5.7.0;python_version>='3.12'
 statsd===4.0.1
 python-keystoneclient===5.4.0
 ceilometer===22.0.0.0rc1


### PR DESCRIPTION
From python3.12, datetime.datetime.utcnow() is unsupported and this
causes Ubuntu Noble Keystone images to fail.

Using 5.7.0 which includes [1] (and the version 2024.2 Keystone uses)
when Python version is 3.12.

[1] https://review.opendev.org/c/openstack/keystoneauth/+/903860